### PR TITLE
Fix for home/menu unlock to work with long-press hardware key actions

### DIFF
--- a/policy/src/com/android/internal/policy/impl/LockScreen.java
+++ b/policy/src/com/android/internal/policy/impl/LockScreen.java
@@ -94,6 +94,7 @@ class LockScreen extends LinearLayout implements KeyguardScreen {
     public static final int LAYOUT_SIX_EIGHT = 1;
 
     private int mLockscreenStyle = LAYOUT_STOCK;
+    private boolean mUnlockKeyDown = false;
 
     private static final int COLOR_WHITE = 0xFFFFFFFF;
 
@@ -769,6 +770,8 @@ class LockScreen extends LinearLayout implements KeyguardScreen {
         if (keyCode == KeyEvent.KEYCODE_BACK
                 || keyCode == KeyEvent.KEYCODE_HOME
                 || keyCode == KeyEvent.KEYCODE_MENU) {
+            // make sure the keydown is from a screen on state
+            mUnlockKeyDown = true;
             event.startTracking();
             return true;
         }
@@ -777,8 +780,12 @@ class LockScreen extends LinearLayout implements KeyguardScreen {
 
     @Override
     public boolean onKeyUp(int keyCode, KeyEvent event) {
-        if ((keyCode == KeyEvent.KEYCODE_MENU && mEnableMenuKeyInLockScreen) ||
-            (keyCode == KeyEvent.KEYCODE_HOME && mHomeUnlockScreen)) {
+        int flags = event.getFlags();
+        // KeyEvent.FLAG_CANCELED_LONG_PRESS checked so we don't unlock after a longpress
+        if (((keyCode == KeyEvent.KEYCODE_MENU && mEnableMenuKeyInLockScreen) ||
+                (keyCode == KeyEvent.KEYCODE_HOME && mHomeUnlockScreen)) &&
+                mUnlockKeyDown && (flags&KeyEvent.FLAG_CANCELED_LONG_PRESS) == 0) {
+            mUnlockKeyDown = false;
             mCallback.goToUnlockScreen();
         }
         return false;


### PR DESCRIPTION
With home/menu unlock enabled, long-press keyup triggers the unlock.  This also fixes the new issue where the keyup for home wake was triggering the unlock unintentionally, bypassing the lockscreen with just 1 home press.

Change-Id: Ic41fc45fa606ad3b11e5545d40ff3e94a698e48b
