### PR TITLE
Correct date line for korean.

### DIFF
--- a/core/res/res/values-ko/donottranslate-cldr.xml
+++ b/core/res/res/values-ko/donottranslate-cldr.xml
@@ -57,5 +57,5 @@
     <string name="full_wday_month_day_no_year">MMMM d일 EEEE</string>
     <string name="abbrev_wday_month_day_no_year">MMMM d일 EEE</string>
     <string name="abbrev_wday_month_day_year">yyyy년 MMM d일 EEE</string>
-    <string name="full_wday_month_day_no_year_split">MMMM d\n일 EEEE</string>
+    <string name="full_wday_month_day_no_year_split">MMMM d일\n EEEE</string>
 </resources>


### PR DESCRIPTION
e.g) (korean)
15      16
DAY(일)   DAY(일)

to

15DAY(일) 16DAY(일)
