### PR TITLE
Fix KeyButtonRipple color lighting after pressing

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/policy/KeyButtonRipple.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/policy/KeyButtonRipple.java
@@ -81,8 +81,8 @@ public class KeyButtonRipple extends Drawable {
         if (mRipplePaint == null) {
             mRipplePaint = new Paint();
             mRipplePaint.setAntiAlias(true);
+            mRipplePaint.setColor(mRippleColor);
         }
-        mRipplePaint.setColor(mRippleColor);
         return mRipplePaint;
     }
 


### PR DESCRIPTION
This fixes the color when pressing the button, after pressing it, it lights the color.
