### PR TITLE
fix WorkSource.getName(int)

### DIFF
--- a/core/java/android/os/WorkSource.java
+++ b/core/java/android/os/WorkSource.java
@@ -93,7 +93,7 @@ public class WorkSource implements Parcelable {
 
     /** @hide */
     public String getName(int index) {
-        return mNames != null ? mNames[index] : null;
+        return mNames != null && nNames.length > index ? mNames[index] : null;
     }
 
     /**


### PR DESCRIPTION
01-16 17:41:19.894   894  2249 W System.err:    at com.android.server.AlarmManagerService.deliverAlarmsLocked(AlarmManagerService.java:2532)
01-16 17:41:19.894   894  2249 W System.err:    at com.android.server.AlarmManagerService$AlarmThread.run(AlarmManagerService.java:2653)
01-16 17:41:19.894   894  2249 W System.err: Caused by: java.lang.ArrayIndexOutOfBoundsException: length=0; index=0
01-16 17:41:19.894   894  2249 W System.err:    at android.os.WorkSource.getName(WorkSource.java:96)
01-16 17:41:19.894   894  2249 W System.err:    ... 13 more